### PR TITLE
Issue #8 - Display timestamps based on timezone

### DIFF
--- a/customer/SwickCustomerIOS.xcodeproj/project.pbxproj
+++ b/customer/SwickCustomerIOS.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 			isa = PBXGroup;
 			children = (
 				1495C751246C770600F30ECB /* LoginVC.swift */,
+				F2B4BE3D250045D500B47615 /* TabBarVC.swift */,
 				1495C73E246B935800F30ECB /* RestaurantVC.swift */,
 				14AA78412484868700145D40 /* CategoryVC.swift */,
 				1495C743246B9C9300F30ECB /* MenuVC.swift */,
@@ -139,7 +140,6 @@
 				1495C74D246BDA0200F30ECB /* OrderVC.swift */,
 				1495C74F246BDA9F00F30ECB /* OrderDetailsVC.swift */,
 				1495C75E246CAB6600F30ECB /* AccountVC.swift */,
-				F2B4BE3D250045D500B47615 /* TabBarVC.swift */,
 			);
 			path = "View Controllers";
 			sourceTree = "<group>";

--- a/customer/SwickCustomerIOS/Helpers/Helper.swift
+++ b/customer/SwickCustomerIOS/Helpers/Helper.swift
@@ -43,6 +43,20 @@ class Helper {
         return String(format: "$%.2f", price)
     }
     
+    // Convert string to date
+    static func convertStringToDate(_ str: String) -> Date {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mmZ"
+        return formatter.date(from: str) ?? Date()
+    }
+    
+    // Convert date to string
+    static func convertDateToString(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MM/dd/yy h:mma"
+        return formatter.string(from: date)
+    }
+    
     // Convert hex integer to UIColor
     static func hexColor(_ hex: Int) -> UIColor {
         return UIColor(

--- a/customer/SwickCustomerIOS/Models/Order.swift
+++ b/customer/SwickCustomerIOS/Models/Order.swift
@@ -13,13 +13,13 @@ class Order {
     var id: Int
     var restaurantName: String
     var status: String
-    var time: String
+    var time: Date
     
     init(json: JSON) {
         self.id = json["id"].int ?? -1
         self.restaurantName = json["restaurant"]["name"].string ?? ""
         self.status = json["status"].string ?? ""
-        self.time = json["order_time"].string ?? ""
+        self.time = Helper.convertStringToDate(json["order_time"].string ?? "")
     }
 }
 

--- a/customer/SwickCustomerIOS/View Controllers/OrderDetailsVC.swift
+++ b/customer/SwickCustomerIOS/View Controllers/OrderDetailsVC.swift
@@ -40,7 +40,7 @@ class OrderDetailsVC: UIViewController {
     
     func loadOrderDetails() {
         // Load time into view with object from previous view
-        timeLabel.text = order.time
+        timeLabel.text = Helper.convertDateToString(order.time)
         
         // Load order details from API call
         APIManager.shared.getOrderDetails(orderId: order.id) { json in

--- a/customer/SwickCustomerIOS/View Controllers/OrderVC.swift
+++ b/customer/SwickCustomerIOS/View Controllers/OrderVC.swift
@@ -74,7 +74,7 @@ class OrderVC: UITableViewController {
         let cell = tableView.dequeueReusableCell(withIdentifier: "OrderCell", for: indexPath) as! OrderCell
         let order = orders[indexPath.row]
         cell.restaurantNameLabel.text = order.restaurantName
-        cell.timeLabel.text = order.time
+        cell.timeLabel.text = Helper.convertDateToString(order.time)
         cell.statusLabel.text = order.status
         return cell
     }


### PR DESCRIPTION
Store timestamps as `Date` objects and use `DateFormatter` to convert `Date` object to `String` based on timezone of phone.